### PR TITLE
FIX BUGS

### DIFF
--- a/bin/gitplus
+++ b/bin/gitplus
@@ -21,7 +21,16 @@ var RE_GIT_REPO_URL = /^([a-zA-Z0-9._-]+)@([a-zA-Z0-9-.]+):(.*)/;
 var args = process.argv.slice(2);
 var subcommand = args[0];
 
-if (GITCONFIG.alias.hasOwnProperty(subcommand)) {
+// [startsWith](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith#Polyfill)
+if (!String.prototype.startsWith) {
+  String.prototype.startsWith = function(searchString, position) {
+    position = position || 0;
+    return this.indexOf(searchString, position) === position;
+  };
+}
+
+// Sometimes, there is no `alias` field in `.gitconfig` file.
+if (GITCONFIG.alias && GITCONFIG.alias.hasOwnProperty(subcommand)) {
   subcommand = GITCONFIG.alias[subcommand].split(/\s/)[0];
   if (subcommand.startsWith('!')) {
     subcommand = '';


### PR DESCRIPTION
1. `startsWith` does not work in node(v0.12.5), so we need a polyfill.
2. Sometimes, there is no `alias` field in `.gitconfig` file. For example, there is only `user` field in my `.gitconfig`:

```
[user]
    name = Benjy Cui
    email = benjytrys@gmail.com
```
